### PR TITLE
chore: Limit query results to top 100 records

### DIFF
--- a/src/XperienceCommunity.AspNetCore.HealthChecks/HealthChecks/EventLogHealthCheck.cs
+++ b/src/XperienceCommunity.AspNetCore.HealthChecks/HealthChecks/EventLogHealthCheck.cs
@@ -82,7 +82,8 @@ namespace XperienceCommunity.AspNetCore.HealthChecks.HealthChecks
                         .And()
                         .WhereGreaterOrEquals(nameof(EventLogInfo.EventTime), DateTime.UtcNow.AddHours(-12)))
                     .Columns(s_columnNames)
-                    .OnSite(SiteContext.CurrentSiteID);
+                    .OnSite(SiteContext.CurrentSiteID)
+                    .TopN(100);
 
                 return await query.ToListAsync(cancellationToken: cancellationToken);
             }


### PR DESCRIPTION
Added the `.TopN(100)` method to restrict the query results to the top 100 records. This change aims to improve performance and manageability by preventing the retrieval of an excessive number of records.