### PR TITLE
chore: Add TopN(100) to health checks and update using directives

### DIFF
--- a/src/XperienceCommunity.AspNetCore.HealthChecks/HealthChecks/AzureSearchTaskHealthCheck.cs
+++ b/src/XperienceCommunity.AspNetCore.HealthChecks/HealthChecks/AzureSearchTaskHealthCheck.cs
@@ -2,6 +2,7 @@
 using CMS.DataEngine;
 using CMS.Search;
 using CMS.Search.Azure;
+using CMS.SiteProvider;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using XperienceCommunity.AspNetCore.HealthChecks.Extensions;
 
@@ -75,7 +76,8 @@ namespace XperienceCommunity.AspNetCore.HealthChecks.HealthChecks
             {
                 var query = _searchTaskAzureInfoProvider.Get()
                     .Columns(s_columnNames)
-                    .WhereNotNullOrEmpty(nameof(SearchTaskAzureInfo.SearchTaskAzureErrorMessage));
+                    .WhereNotNullOrEmpty(nameof(SearchTaskAzureInfo.SearchTaskAzureErrorMessage))
+                    .TopN(100);
                 
                 return await query.ToListAsync(cancellationToken: cancellationToken);
             }

--- a/src/XperienceCommunity.AspNetCore.HealthChecks/HealthChecks/LocalSearchTaskHealthCheck.cs
+++ b/src/XperienceCommunity.AspNetCore.HealthChecks/HealthChecks/LocalSearchTaskHealthCheck.cs
@@ -66,7 +66,8 @@ namespace XperienceCommunity.AspNetCore.HealthChecks.HealthChecks
                 var query = _searchTaskInfoProvider.Get()
                     .Columns(s_columnNames)
                     .WhereNotNullOrEmpty(nameof(SearchTaskInfo.SearchTaskErrorMessage))
-                    .OnSite(SiteContext.CurrentSiteID);
+                    .OnSite(SiteContext.CurrentSiteID)
+                    .TopN(100);
 
                 return await query.ToListAsync(cancellationToken: cancellationToken);
             }


### PR DESCRIPTION
Updated AzureSearchTaskHealthCheck.cs to include additional using
directives for CMS.SiteProvider, Microsoft.Extensions.Diagnostics.
HealthChecks, and XperienceCommunity.AspNetCore.HealthChecks.Extensions.
Modified LINQ queries in AzureSearchTaskHealthCheck and
LocalSearchTaskHealthCheck to limit results to the top 100 entries
using the .TopN(100) method call.